### PR TITLE
Initial Atmel EDBG support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1027,6 +1027,11 @@ export function getMbedDevices() {
     return devices.filter(d => /MBED CMSIS-DAP/.test(d.product))
 }
 
+export function getEdbgDevices() {
+    let devices = HID.devices() as HidDevice[]
+    return devices.filter(d => /EDBG CMSIS-DAP/.test(d.product))
+}
+
 export interface Map<T> {
     [n: string]: T;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,9 +265,16 @@ export class Dap {
     private sent: CmdEntry[] = [];
     private waiting: CmdEntry[] = [];
     private maxSent = 1;
+    private packetLength = 64;
 
     constructor(path: string) {
         this.dev = new HID.HID(path)
+
+        var deviceInfo = this.dev.getDeviceInfo();
+
+        if (deviceInfo && deviceInfo.manufacturer === 'Atmel Corp.') {
+            this.packetLength = 513;
+        }
 
         this.dev.on("data", (buf: Buffer) => {
             let c = this.sent.shift()
@@ -296,7 +303,7 @@ export class Dap {
 
     private sendNums(lst: number[]) {
         lst.unshift(0)
-        while (lst.length < 64)
+        while (lst.length < this.packetLength)
             lst.push(0)
         this.dev.write(lst)
     }


### PR DESCRIPTION
Thanks for open sourcing this project!

Here are some initial changes to support the Atmel EDBG on the [Arduino Zero](https://www.arduino.cc/en/Main/ArduinoBoardZero) board.

So far I can connect, halt, and read the devices flash:

```javascript
var dapjs = require('dapjs');

var edbgHid = dapjs.getEdbgDevices()[0];

var edbg = new dapjs.Device(edbgHid.path);


edbg.initAsync().then(function() {
  console.log('initialized');

  return edbg.haltAsync();
}).then(function(err) {
  console.log('halted'); 

  return edbg.snapshotHexAsync();
}).then(function(hex) {
  console.log(hex);
});
```

Still working on testing how to flash the device.